### PR TITLE
docs: fix simple typo, puposes -> purposes

### DIFF
--- a/src/puthread.h
+++ b/src/puthread.h
@@ -82,7 +82,7 @@
  * p_uthread_replace_local(). The only difference is that the former one calls
  * the provided destroy notification function before replacing the old value.
  *
- * Thread names are used on most of operating systems for debugging puposes,
+ * Thread names are used on most of operating systems for debugging purposes,
  * thereby some limitations for long name can be applied and too long names
  * will be truncated automatically.
  */


### PR DESCRIPTION
There is a small typo in src/puthread.h.

Should read `purposes` rather than `puposes`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md