### PR TITLE
add CMP0063 policy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,8 @@ set (CMAKE_LEGACY_CYGWIN_WIN32 0)
 cmake_minimum_required (VERSION 2.8.0...3.25.1)
 project (plibsys C)
 
+cmake_policy(SET CMP0063 NEW)
+
 set (PLIBSYS_VERSION_MAJOR 0)
 set (PLIBSYS_VERSION_MINOR 0)
 set (PLIBSYS_VERSION_PATCH 4)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,10 @@ set (CMAKE_LEGACY_CYGWIN_WIN32 0)
 cmake_minimum_required (VERSION 2.8.0...3.25.1)
 project (plibsys C)
 
-cmake_policy(SET CMP0063 NEW)
+# Introduced in CMake 3.3, may produce warnings with CMake < 3.12
+if (POLICY CMP0063)
+    cmake_policy (SET CMP0063 NEW)
+endif()
 
 set (PLIBSYS_VERSION_MAJOR 0)
 set (PLIBSYS_VERSION_MINOR 0)


### PR DESCRIPTION
3.27.7 started actively warning if CMP0063 isn't set, which pollutes a project depending on plibsys with a lot of warnings.